### PR TITLE
persist board the user came in from

### DIFF
--- a/lib/lucidboard_web/controllers/auth_controller.ex
+++ b/lib/lucidboard_web/controllers/auth_controller.ex
@@ -4,7 +4,7 @@ defmodule LucidboardWeb.AuthController do
   """
   use LucidboardWeb, :controller
   alias Lucidboard.Account
-  alias LucidboardWeb.DashboardLive
+  alias LucidboardWeb.{BoardLive, DashboardLive}
   alias LucidboardWeb.Router.Helpers, as: Routes
   alias Ueberauth.Strategy.Helpers
 
@@ -15,6 +15,8 @@ defmodule LucidboardWeb.AuthController do
   end
 
   def dumb_signin(conn, %{"signin" => %{"username" => username}}) do
+    board_id = get_session(conn, :signin_board_id)
+
     if Lucidboard.auth_provider() != :dumb do
       {:error, :not_found}
     else
@@ -25,16 +27,18 @@ defmodule LucidboardWeb.AuthController do
 
           conn
           |> put_session(:user_id, user.id)
+          |> put_session(:signin_board_id, nil)
           |> put_flash(:info, """
           We've created your account and you're now signed in!
           """)
-          |> redirect(to: Routes.live_path(conn, DashboardLive))
+          |> redirect(to: get_redirect_path(conn, board_id))
 
         user ->
           conn
           |> put_session(:user_id, user.id)
+          |> put_session(:signin_board_id, nil)
           |> put_flash(:info, "You have successfully signed in!")
-          |> redirect(to: Routes.live_path(conn, DashboardLive))
+          |> redirect(to: get_redirect_path(conn, board_id))
       end
     end
   end
@@ -53,12 +57,15 @@ defmodule LucidboardWeb.AuthController do
   end
 
   def callback(%{assigns: %{ueberauth_auth: auth}} = conn, _params) do
+    board_id = get_session(conn, :signin_board_id)
+
     case Account.auth_to_user(auth) do
       {:ok, user} ->
         conn
         |> put_session(:user_id, user.id)
+        |> put_session(:signin_board_id, nil)
         |> put_flash(:info, "Hello, #{user.name}!")
-        |> redirect(to: Routes.live_path(conn, DashboardLive))
+        |> redirect(to: get_redirect_path(conn, board_id))
 
       {:error, reason} ->
         conn
@@ -66,4 +73,10 @@ defmodule LucidboardWeb.AuthController do
         |> redirect(to: "/")
     end
   end
+
+  defp get_redirect_path(conn, nil),
+    do: Routes.live_path(conn, DashboardLive)
+
+  defp get_redirect_path(conn, board_id),
+    do: Routes.live_path(conn, BoardLive, board_id)
 end

--- a/lib/lucidboard_web/controllers/user_controller.ex
+++ b/lib/lucidboard_web/controllers/user_controller.ex
@@ -7,13 +7,15 @@ defmodule LucidboardWeb.UserController do
 
   @themes Application.get_env(:lucidboard, :themes)
 
-  def signin(conn, _params) do
+  def signin(conn, params) do
     if signed_in?(conn) do
       conn
       |> put_status(:see_other)
       |> redirect(to: Routes.live_path(conn, DashboardLive))
     else
-      render(conn, "signin.html")
+      board_id = Map.get(params, "board_id", nil)
+      conn = put_session(conn, :signin_board_id, board_id)
+      render(conn, "signin.html", board_id: board_id)
     end
   end
 

--- a/lib/lucidboard_web/live/board_live.ex
+++ b/lib/lucidboard_web/live/board_live.ex
@@ -25,11 +25,11 @@ defmodule LucidboardWeb.BoardLive do
     BoardView.render("index.html", assigns)
   end
 
-  def mount(%{user_id: nil}, socket) do
+  def mount(%{user_id: nil, path_params: %{"id" => board_id}}, socket) do
     socket =
       socket
       |> put_flash(:error, "You must be signed in")
-      |> redirect(to: Routes.user_path(Endpoint, :signin))
+      |> redirect(to: Routes.user_path(Endpoint, :signin, board_id: board_id))
 
     {:stop, socket}
   end


### PR DESCRIPTION
If user is not signed in, and they come in on:
localhost:8800/board/1
they will be forced to sign in, then taken back to localhost:8800/board/1, instead of the dashboard